### PR TITLE
Flip local video stream

### DIFF
--- a/src/assets/css/app.css
+++ b/src/assets/css/app.css
@@ -83,6 +83,13 @@ body {
   z-index: 1000;
 }
 
+.mirror-mode{
+  -ms-transform: scaleX(-1);
+  -moz-transform: scaleX(-1);
+  -webkit-transform: scaleX(-1);
+  transform: scaleX(-1);
+}
+
 .sender-info {
   font-size: smaller;
   margin-top: 5px;

--- a/src/index.html
+++ b/src/index.html
@@ -180,7 +180,7 @@
 
     <div class="container-fluid room-comm" hidden>
       <div class="row">
-        <video class="local-video clipped" id="local" volume="0" autoplay muted></video>
+        <video class="local-video clipped mirror-mode" id="local" volume="0" autoplay muted></video>
       </div>
 
       <div class="row">


### PR DESCRIPTION
Fix the wrong display of the local video stream. There is a caveat to this fix. 

If screen sharing is enabled, the user's screen will be flipped RTL. This is why I added a separate class for flipping the stream. The class can be toggled based on the current media the user is streaming. 

If user is sharing video, the class will be added. If user is sharing screen, the class will be removed.